### PR TITLE
added support for glad

### DIFF
--- a/libs/renderer/glad/meson.build
+++ b/libs/renderer/glad/meson.build
@@ -1,0 +1,23 @@
+wget = find_program('wget')
+
+glad_c = 'https://glad.dav1d.de/generated/tmpea6a7ubnglad/src/glad.c'
+glad_h = 'https://glad.dav1d.de/generated/tmpea6a7ubnglad/include/glad/glad.h'
+
+outfile_c = 'glad.c'
+outfile_h = 'glad.h'
+
+code = custom_target(
+    output: outfile_c,
+    command: [wget, glad_c, '-O', '@OUTPUT@'],
+    install: true,
+    install_dir: 'glad'
+)
+
+header = custom_target(
+    output: outfile_h,
+    command: [wget, glad_h, '-O', '@OUTPUT@'],
+    install: true,
+    install_dir: 'glad'
+)
+
+renderer_files += [header, code]

--- a/libs/renderer/include/renderer/renderer.h
+++ b/libs/renderer/include/renderer/renderer.h
@@ -8,7 +8,7 @@
 #define _RENDERER_RENDERER_H_
 
 #ifdef __cplusplus
-extern "c" {
+extern "C" {
 #endif
 
 void test(void);

--- a/libs/renderer/meson.build
+++ b/libs/renderer/meson.build
@@ -1,9 +1,9 @@
 project(
-	'angel',
+	'renderer',
 	'c',
 	version: '0.0.1',
 	license: 'Apache-2.0',
-	meson_version: '>=0.58.1',
+	meson_version: '>=0.60.1',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -38,23 +38,24 @@ renderer_files = []
 
 subdir('renderer')
 subdir('include')
+subdir('glad')
 
-renderer_deps = [
+lib_renderer_deps = [
 	math,
 ]
 
-renderer_inc = include_directories('include')
+lib_renderer_inc = include_directories('include')
 
-librenderer = library(
+lib_renderer = library(
 	meson.project_name(), renderer_files,
 	soversion: soversion,
-	dependencies: renderer_deps,
-	include_directories: [renderer_inc],
+	dependencies: lib_renderer_deps,
+	include_directories: [lib_renderer_inc],
 	install: true,
 )
 
 pkgconfig = import('pkgconfig')
-pkgconfig.generate(librenderer,
+pkgconfig.generate(lib_renderer,
 	version: meson.project_version(),
 	filebase: meson.project_name(),
 	name: meson.project_name(),


### PR DESCRIPTION
RENDERER:

Loading glad at compile time with wget. Generated with: [Glad generator](https://glad.dav1d.de/#language=c&specification=gl&api=gl%3D4.6&api=gles1%3Dnone&api=gles2%3Dnone&api=glsc2%3Dnone&profile=core&loader=on)

